### PR TITLE
Fix missing druid treant form condition

### DIFF
--- a/Tongues/Tongues.lua
+++ b/Tongues/Tongues.lua
@@ -1403,7 +1403,9 @@ HandleSend = function(self, msg, chatType, langID, language, channel)--HANDLE TE
 						else
 							s = T_Moonkin;
 						end
-	
+						
+					elseif name == "Treant Form" then
+						s = T_Trentish;
 					
 					elseif name == "Flight Form" or name == "Swift Flight Form" then
 					 if UnitRace("player")==BRAC["Troll"] then


### PR DESCRIPTION
Using the druid treant form with tongues active would cause you to be unable to enter text in any chat. This was due to a missing condition check for the druid treant form. This patch adds that check, and tested successfully locally.