### PR TITLE
Fix issues with DF Tongues

### DIFF
--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -109,10 +109,9 @@ end;
 			OnMouseUp = function(self,button)
 				if button == "RightButton" then
 				  if IsAltKeyDown() then
-				  Tongues:UpdateDialectContext2();
-	              Tongues.MenuClass:Show();
+					Tongues:UpdateDialectContext2();
+					Tongues.MenuClass:Show();
 				  else
-					self:Hide();
 					Tongues.UI.MainMenu.Frame:Show();
 				 end
 				else

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -474,8 +474,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Speak.DialectDrift.Frame:SetChecked(not Tongues.UI.MainMenu.Speak.DialectDrift.Frame:GetChecked());
-								
 						if (Tongues.UI.MainMenu.Speak.DialectDrift.Frame:GetChecked() == true) then
 							--Tongues.Settings.Character.Translations.Self = true;
 						else
@@ -513,8 +511,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Speak.LanguageLearn.Frame:SetChecked(not Tongues.UI.MainMenu.Speak.LanguageLearn.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Speak.LanguageLearn.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.LanguageLearning = true;
 						else
@@ -552,8 +548,6 @@ end;
 					end;
 		
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Speak.ShapeshiftLanguage.Frame:SetChecked(not Tongues.UI.MainMenu.Speak.ShapeshiftLanguage.Frame:GetChecked());
-								
 						if (Tongues.UI.MainMenu.Speak.ShapeshiftLanguage.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.ShapeshiftLanguage = true;
 							--print(Tongues.Settings.Character.ShapeshiftLanguage)
@@ -598,8 +592,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Speak.MiniHide.Frame:SetChecked(not Tongues.UI.MainMenu.Speak.MiniHide.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Speak.MiniHide.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.MMH = true;
 							TonguesMiniMenu:Hide();
@@ -640,7 +632,6 @@ end;
 					end;
 		
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Speak.LoreCompatibility.Frame:SetChecked(not Tongues.UI.MainMenu.Speak.LoreCompatibility.Frame:GetChecked());
 						if Tongues.UI.MainMenu.Speak.LoreCompatibility.Frame:GetChecked() == true then
 							--RemoveChatWindowChannel(1, "xtensionxtooltip2")
 							JoinChannelByName("xtensionxtooltip2")
@@ -1162,8 +1153,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Self.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Self.Frame:GetChecked());
-							
 						if (Tongues.UI.MainMenu.Translations.Self.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Self = true;
 						else
@@ -1202,8 +1191,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Targetted.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Targetted.Frame:GetChecked());
-							
 						if (Tongues.UI.MainMenu.Translations.Targetted.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Targetted = true;
 						else
@@ -1242,8 +1229,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Party.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Party.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Translations.Party.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Party = true;
 						else
@@ -1282,8 +1267,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Guild.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Guild.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Translations.Guild.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Guild = true;
 						else
@@ -1322,8 +1305,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Officer.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Officer.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Translations.Officer.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Officer = true;
 						else
@@ -1362,8 +1343,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Raid.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Raid.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Translations.Raid.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Raid = true;
 						else
@@ -1402,8 +1381,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.RaidAlert.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.RaidAlert.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Translations.RaidAlert.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.RaidAlert = true;
 						else
@@ -1442,8 +1419,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Translations.Battleground.Frame:SetChecked(not Tongues.UI.MainMenu.Translations.Battleground.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Translations.Battleground.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Translations.Battleground = true;
 						else
@@ -1653,8 +1628,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Self.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Self.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.Self.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Self = true;
 						else
@@ -1693,8 +1666,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Targetted.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Targetted.Frame:GetChecked());
-							
 						if (Tongues.UI.MainMenu.Screen.Targetted.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Targetted = true;
 						else
@@ -1733,8 +1704,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Party.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Party.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.Party.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Party = true;
 						else
@@ -1773,8 +1742,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Guild.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Guild.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.Guild.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Guild = true;
 						else
@@ -1813,8 +1780,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Officer.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Officer.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.Officer.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Officer = true;
 						else
@@ -1853,8 +1818,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Raid.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Raid.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.Raid.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Raid = true;
 						else
@@ -1893,8 +1856,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.RaidAlert.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.RaidAlert.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.RaidAlert.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.RaidAlert = true;
 						else
@@ -1933,8 +1894,6 @@ end;
 					end;
 	
 					OnMouseUp = function(self)
-						Tongues.UI.MainMenu.Screen.Battleground.Frame:SetChecked(not Tongues.UI.MainMenu.Screen.Battleground.Frame:GetChecked());
-
 						if (Tongues.UI.MainMenu.Screen.Battleground.Frame:GetChecked() == true) then
 							Tongues.Settings.Character.Screen.Battleground = true;
 						else

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -1039,7 +1039,7 @@ end;
 				end;
 
 				OnMouseUp = function(self)
-					if Tongues.UI.MainMenu.AdvancedOptions.Frame:IsVisible() == 1 then
+					if Tongues.UI.MainMenu.AdvancedOptions.Frame:IsVisible() == true then
 						Tongues.UI.MainMenu.AdvancedOptions.Frame:Hide()
 					else
 						Tongues.UI.MainMenu.AdvancedOptions.Frame:Show()

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -988,7 +988,7 @@ end;
 					self.Frame:SetFrameStrata("DIALOG")
 					--self.Frame:SetWidth(10)
 			    	    	--self.Frame:SetHeight(10)
-					self.Frame:SetPoint("TOPRIGHT", Tongues.UI.MainMenu.Frame, 2,-9);
+					self.Frame:SetPoint("TOPRIGHT", Tongues.UI.MainMenu.Frame, 0,-12);
 					--self.texture[1] = self.Frame:CreateTexture("settings","BUTTON")
 					--self.texture[1]:SetTexture("Interface\\Buttons\\UI-Panel-MinimizeButton-Up")
 					--self.texture[1]:SetPoint("CENTER", self.Frame, "CENTER", 0, 0);

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -90,7 +90,7 @@ end;
 				self.Frame = CreateFrame("Button","TonguesMiniMenu",UIParent, "UIPanelButtonTemplate");
 				self.Frame:SetScript("OnDragStart", self.OnDragStart);
 				self.Frame:SetScript("OnDragStop", self.OnDragStop);
-				self.Frame:SetScript("OnMouseUp", self.OnMouseUp);
+				self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 				self.Frame:SetFrameStrata("MEDIUM")
 				self.Frame:SetMovable(true)
 				self.Frame:SetWidth(100)
@@ -106,7 +106,7 @@ end;
 				self.Frame:Show();
 			end;
 
-			OnMouseUp = function(self,button)
+			OnMouseDown = function(self,button)
 				if button == "RightButton" then
 				  if IsAltKeyDown() then
 					Tongues:UpdateDialectContext2();

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -139,7 +139,7 @@ end;
 
 			Configure = function(self)
 				self.Frame = CreateFrame("Frame","TonguesMainMenu",UIParent);
-				self.Frame:SetScript("OnKeyUp", self.OnKeyDown);
+				self.Frame:SetScript("OnKeyDown", self.OnKeyDown);
 				self.Frame:SetScript("OnDragStart", self.OnDragStart);
 				self.Frame:SetScript("OnDragStop", self.OnDragStop);
 				self.Frame:SetFrameStrata("DIALOG")
@@ -198,9 +198,11 @@ end;
 
 			OnKeyDown = function (self,button)
 				if button == "ESCAPE" then
-					self:Hide()
-					Tongues.UI.MiniMenu.Frame:Show()
-				end;
+					self:SetPropagateKeyboardInput(false);
+					self:Hide();
+				else
+					self:SetPropagateKeyboardInput(true);
+				end
 			end;
 
 			OnDragStart = function (self)

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -454,7 +454,7 @@ end;
 					text	 = {};
 		
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","DialectDrift", Tongues.UI.MainMenu.Speak.Frame);
+						self.Frame = CreateFrame("CheckButton","DialectDrift", Tongues.UI.MainMenu.Speak.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -493,7 +493,7 @@ end;
 					text	 = {};
 		
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","LanguageLearn", Tongues.UI.MainMenu.Speak.Frame);
+						self.Frame = CreateFrame("CheckButton","LanguageLearn", Tongues.UI.MainMenu.Speak.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -532,7 +532,7 @@ end;
 					text	 = {};
 		
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ShapeShiftLanguage", Tongues.UI.MainMenu.Speak.Frame);
+						self.Frame = CreateFrame("CheckButton","ShapeShiftLanguage", Tongues.UI.MainMenu.Speak.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -577,14 +577,14 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","HideMiniF", Tongues.UI.MainMenu.Speak.Frame);
+						self.Frame = CreateFrame("CheckButton","HideMiniF", Tongues.UI.MainMenu.Speak.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
 	
 						self.text[1] = self.Frame:CreateFontString("settings",nil)
 						self.text[1]:SetFont(GameFontNormal:GetFont(),12);
-						self.text[1]:SetText('|cffffffffHide\nMiniMenu|r')
+						self.text[1]:SetText('|cffffffffHide MiniMenu|r')
 						self.text[1]:SetPoint("LEFT", self.Frame, "LEFT",25, 0 );
 	
 						self.Frame:SetWidth(25)
@@ -620,7 +620,7 @@ end;
 					text	 = {};
 		
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","LoreCompatibility", Tongues.UI.MainMenu.Speak.Frame);
+						self.Frame = CreateFrame("CheckButton","LoreCompatibility", Tongues.UI.MainMenu.Speak.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1141,7 +1141,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsSelf", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsSelf", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1181,7 +1181,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsTargetted", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsTargetted", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1221,7 +1221,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsParty", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsParty", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1261,7 +1261,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsGuild", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsGuild", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1301,7 +1301,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsOfficer", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsOfficer", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1341,7 +1341,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsRaidButton", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsRaidButton", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1381,7 +1381,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsRaidAlert", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsRaidAlert", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1421,7 +1421,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","TranslationsBattleground", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","TranslationsBattleground", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1632,7 +1632,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenSelf", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenSelf", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1672,7 +1672,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenTargetted", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenTargetted", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1712,7 +1712,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenParty", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenParty", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1752,7 +1752,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenGuild", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenGuild", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1792,7 +1792,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenOfficer", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenOfficer", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1832,7 +1832,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenRaidButton", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenRaidButton", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1872,7 +1872,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenRaidAlert", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenRaidAlert", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")
@@ -1912,7 +1912,7 @@ end;
 					text	 = {};
 	
 					Configure = function(self)
-						self.Frame = CreateFrame("CheckButton","ScreenBattleground", Tongues.UI.MainMenu.AdvancedOptions.Frame);
+						self.Frame = CreateFrame("CheckButton","ScreenBattleground", Tongues.UI.MainMenu.AdvancedOptions.Frame, "UICheckButtonTemplate");
 						self.Frame:SetScript("OnMouseDown", self.OnMouseDown);
 						self.Frame:SetScript("OnMouseUp", self.OnMouseUp);				
 						self.Frame:SetFrameStrata("DIALOG")

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -141,6 +141,7 @@ end;
 				self.Frame:SetScript("OnKeyDown", self.OnKeyDown);
 				self.Frame:SetScript("OnDragStart", self.OnDragStart);
 				self.Frame:SetScript("OnDragStop", self.OnDragStop);
+				self.Frame:SetScript("OnShow", self.OnShow);
 				self.Frame:SetFrameStrata("DIALOG")
 				self.Frame:SetMovable(true)
 				self.Frame:SetWidth(348)
@@ -193,6 +194,13 @@ end;
 				self.AdvancedOptions:Configure();
 				
 				self.Frame:Hide();
+			end;
+
+			OnShow = function (self)
+				-- Necessary to stop CloseButton from being stuck in PUSHED state
+				if (Tongues.UI.MainMenu.CloseButton.Frame:GetButtonState() == "PUSHED") then
+					Tongues.UI.MainMenu.CloseButton.Frame:SetButtonState("NORMAL");
+				end
 			end;
 
 			OnKeyDown = function (self,button)

--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -108,12 +108,14 @@ end;
 
 			OnMouseDown = function(self,button)
 				if button == "RightButton" then
-				  if IsAltKeyDown() then
-					Tongues:UpdateDialectContext2();
-					Tongues.MenuClass:Show();
-				  else
-					Tongues.UI.MainMenu.Frame:Show();
-				 end
+					if Tongues.UI.MainMenu.Frame:IsVisible() == true then
+						Tongues.UI.MainMenu.Frame:Hide();
+					elseif IsAltKeyDown() then
+						Tongues:UpdateDialectContext2();
+						Tongues.MenuClass:Show();
+					else
+						Tongues.UI.MainMenu.Frame:Show();
+					end
 				else
 				   --if countLangauge() ~= 0 then
 					Tongues:CycleLanguage();


### PR DESCRIPTION
Has enough in it for now, cutting up the commits in seperate ones (you can squash if you'd like) so it's easier to follow along what each one changes.

**Keep in mind this PR depends on #5 to re-enable dragging.**

Issues To-Do:
- [x] Checkboxes invisible
- [x] Dragging button (see #5)
- [x] Dragging main window (see #5)
- [x] Checkboxes don't check on left click
- [x] Main Window blocks keyboard input
- [x] Advanced Options button doesn't toggle (can't hide it)
- [x] Mini button is always hidden on right-click (even when option is not checked)
- [x] Close button no longer fits window
- [x] Close button stuck on PUSHED state (pressed in)
- [x] MiniMenu button stuck on PUSHED state when clicked or dragging it (after applying #5)

Still to Fix (different PRs most likely)
Dropdowns are not showing (something related to ElioteDropDownMenu, will be in another PR if I figure it out.

Below is an explanation of each commit;

**Fix Checkbutton styling**
Self-explanatory, checkbuttons (checkboxes) are once again showing little squares.

**Fix checkbuttons unchecking on left-click**
I have no clue why this not was initially added, but I've tested the menu extensively and it all works as per usual even without these lines in.

**Fix main menu blocking keyboard (escape exits)**
Main menu was blocking all keyboard input as it was continuously listening for the escape key to close it. It still does this, but now allows other keys to work during. Also removed the Mini Menu forcefully showing since it should depend on the "Hide MiniMenu" option as-is.

**Fix advanced options button toggle**
Advanced Options button did not toggle itself, this has been corrected.

**Don't hide mini button on right click**
It will still respect the "Hide Minimenu" option and not show when that is clicked, but having it hide itself by default even when the user has not selected that option makes no real sense and is just confusing.

**Fit the close button better in main menu**
A visual thing, it seemed to be out of bounds in the main menu thanks to DF.

**Fix close button stuck on PUSHED state**
Once you clicked the close button, it was stuck on the pushed state. This resolves that.

**Fix MiniMenu stuck on PUSHED state**
Click anything, dragging (from my other commit #5 or anything else with that button would keep it stuck in a pressed in (PUSHED) state unless you used MouseDown.

**Right-click MiniMenu now toggles main menu**
Considering right-clicking opened the Main Menu, it seemed logical that right-clicking it again when it is already open closes it. So a simple toggle as a QoL idea.