### PR TITLE
Remove UIParent from settings

### DIFF
--- a/Core/UI.lua
+++ b/Core/UI.lua
@@ -129,7 +129,8 @@ end;
 
 			OnDragStop = function (self)
 				self:StopMovingOrSizing();
-				Tongues.Settings.Character.UI.MiniMenu.point, Tongues.Settings.Character.UI.MiniMenu.relativeTo, Tongues.Settings.Character.UI.MiniMenu.relativePoint, Tongues.Settings.Character.UI.MiniMenu.xOfs, Tongues.Settings.Character.UI.MiniMenu.yOfs = self:GetPoint();
+				local relativeTo;
+				Tongues.Settings.Character.UI.MiniMenu.point, relativeTo, Tongues.Settings.Character.UI.MiniMenu.relativePoint, Tongues.Settings.Character.UI.MiniMenu.xOfs, Tongues.Settings.Character.UI.MiniMenu.yOfs = self:GetPoint();
 			end;
 		};
         	
@@ -220,7 +221,8 @@ end;
 
 			OnDragStop = function (self)
 				self:StopMovingOrSizing();
-				Tongues.Settings.Character.UI.MainMenu.point, Tongues.Settings.Character.UI.MainMenu.relativeTo, Tongues.Settings.Character.UI.MainMenu.relativePoint, Tongues.Settings.Character.UI.MainMenu.xOfs, Tongues.Settings.Character.UI.MainMenu.yOfs = self:GetPoint();
+				local relativeTo;
+				Tongues.Settings.Character.UI.MainMenu.point, relativeTo, Tongues.Settings.Character.UI.MainMenu.relativePoint, Tongues.Settings.Character.UI.MainMenu.xOfs, Tongues.Settings.Character.UI.MainMenu.yOfs = self:GetPoint();
 			end;
 			--=======================================================================================================
 			SpeakButton = {

--- a/Tongues.lua
+++ b/Tongues.lua
@@ -145,15 +145,13 @@ Tongues = Class:inherits(Tongues,{
 			};
 			UI = {
 				MainMenu = {
-					point = "CENTER", 
-					relativeTo = UIParent, 
+					point = "CENTER",
 					relativePoint = "CENTER",
 					xOfs = 0;
 					yOfs = 0;
 				};
 				MiniMenu = {
-					point = "CENTER", 
-					relativeTo = UIParent, 
+					point = "CENTER",
 					relativePoint = "CENTER",
 					xOfs = 0;
 					yOfs = 0;
@@ -537,10 +535,17 @@ end;
 				end;
 			end;
 			--Lib_UIDropDownMenu_Initialize(Tongues.UI.MainMenu.Speak.LanguageDropDown.Frame, Tongues.UpdateLanguageDropDown);	
-			
+
 			
 			self:SetLanguage(self.Settings.Character.Language);
-			
+
+			-- Removing UIParent from settings
+			if self.Settings.Character.UI.MiniMenu.relativeTo then
+				self.Settings.Character.UI.MiniMenu.relativeTo = nil;
+			end
+			if self.Settings.Character.UI.MainMenu.relativeTo then
+				self.Settings.Character.UI.MainMenu.relativeTo = nil;
+			end
 			
 			----------------------
 			self.Settings.Global = Tongues_Global;


### PR DESCRIPTION
Someone mentioned on our server having an incredibly large Tongues SavedVariables and sent it to me so I could investigate, ended up finding UIParent saved directly in the settings.

Given that StartMoving/StopMovingOrSizing will always anchor to UIParent and that the code reloading the frame position directly uses UIParent as well (see https://github.com/Aurorablade/Tongues/blob/master/Core/UI.lua#L70), it made sense to me to simply remove the field from the settings, and make sure it gets cleaned up for anyone who still has the frame saved.